### PR TITLE
Add schema

### DIFF
--- a/coiba_capuchins_july_2021_20211019_123741.yml
+++ b/coiba_capuchins_july_2021_20211019_123741.yml
@@ -1,62 +1,59 @@
 # Data Catalog Entry: coiba_capuchins_july_2021
 data_catalog_entry_id: coiba_capuchins_july_2021
-data_catalog_entry_details_01:
-  project_name: capuchin_coiba
-  server_adress: smb://10.126.19.90/EAS_shared/capuchin_coiba/working/newdata/capuchins_coiba_july_2021
-person_01:
-  name: Brendan Barrett
-  institute: Max Planck Institute of Animal Behavior
-  email: bbarrett@ab.mpg.de
-  role: PI
-  uploader: 'Yes'
-person_02:
-  name: Zoë Goldsborough
-  institute: Max Planck Institute of Animal Behavior
-  email: zgoldsborough@ab.mpg.de
-  role: PhD Student
-  uploader: 'No'
-person_03:
-  name: Evelyn del Rosario Vargas
-  institute: STRI
-  email: ''
-  role: Field Assistant
-  uploader: 'No'
-species_1:
-  name_eng: white-faced capuchin monkey
-  name_loc: mono cariblanco
-  name_sci: Cebus imitator
-species_2:
-  name_eng: ''
-  name_loc: ''
-  name_sci: Vasula melones
-location_1:
-  country: Panama
-  region: Veraguas,
-  park: Coiba National Park
-  field_station: STRI Rancheria
-  lat_log: 7.4693 N; 81.7568 E
+data_catalog_entry_details:
+  - project_name: capuchin_coiba
+    server_adress: smb://10.126.19.90/EAS_shared/capuchin_coiba/working/newdata/capuchins_coiba_july_2021
+people:
+  - name: Brendan Barrett
+    institute: Max Planck Institute of Animal Behavior
+    email: bbarrett@ab.mpg.de
+    role: PI
+    uploader: true
+  - name: Zoë Goldsborough
+    institute: Max Planck Institute of Animal Behavior
+    email: zgoldsborough@ab.mpg.de
+    role: PhD Student
+    uploader: false
+  - name: Evelyn del Rosario Vargas
+    institute: STRI
+    email: ''
+    role: Field Assistant
+    uploader: false
+species:
+  - name_eng: white-faced capuchin monkey
+    name_loc: mono cariblanco
+    name_sci: Cebus imitator
+  - name_eng: ''
+    name_loc: ''
+    name_sci: Vasula melones
+location:
+  - country: Panama
+    region: Veraguas,
+    park: Coiba National Park
+    field_station: STRI Rancheria
+    lat_log: 7.4693 N; 81.7568 E
 dates:
-  Data Collection: 2021-07-14 - 2021-07-26
+  start_date: 2021-07-14
+  end_date: 2021-07-26
 data_type_overview:
-  data_type_1: behavioral
-  data_type_2: camera trap
-  data_type_3: DNA samples
-  data_type_4: ecological
-  data_type_5: spatial
+  - behavioral
+  - camera trap
+  - DNA samples
+  - ecological
+  - spatial
 data_description:
-  data_desc_1: This is raw camera trap data deployed by Claudio and others in February
+  - "This is raw camera trap data deployed by Claudio and others in February
     2020. It also contains data bout collected DNA samples, photos from trip, Kobo
     collect output from camera trap and tool survey data, and csvs of raw material
     surveys for Meredith's dissertation as well as written summaries of our field
-    trip.
+    trip."
 funding_sources:
-  fund_1: Humboldt Fellowship
-  fund_2: Max Planck Geschellschaft
+  - Humboldt Fellowship
+  - Max Planck Geschellschaft
 keywords:
-  keyword_1: capuchin
-  keyword_2: coiba
-  keyword_3: primate archaeology
-  keyword_4: camera trap
-  keyword_5: social learning
-modified_at_utc:
-- 2021-10-19 10:37:42
+  - capuchin
+  - coiba
+  - primate archaeology
+  - camera trap
+  - social learning
+modified_at: 2021-10-19T10:37:42+00:00

--- a/data-catalog-entry-schema.json
+++ b/data-catalog-entry-schema.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MPI AB EAS Data Catalog Schema",
+  "type": "object",
+  "properties": {
+    "data_catalog_entry_id": {
+      "title": "Data Catalog Entry Id",
+      "description": "This is unique identifier for the entry you data catalog entry you want to archive. For example one could use `coiba_capuchins_july_2021` or `kob_apple_data_2021`.",
+      "type": "string"
+    },
+    "data_catalog_entry_details": {
+      "title": "Data Catalog Entry Details",
+      "description": "This is particular info about the entry.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "project_name": {
+            "title": "Project Name",
+            "description": "This is the name of your server folder if it is a long term project. It is a drop down menu which needs to get updated as projects are added.",
+            "type": "string",
+            "enum": [
+              "food-for-thought",
+              "baboon",
+              "bat_foraging",
+              "bci_general",
+              "human_network_coordination",
+              "blackbuck",
+              "hyena",
+              "bonobo",
+              "kinkajou_cognition",
+              "lion",
+              "meerkat",
+              "capuchin_bci",
+              "mpala_general",
+              "capuchin_coiba",
+              "ngogo_monkey",
+              "capuchin_lomas",
+              "orangutan",
+              "capuchin_santarosa",
+              "ccas",
+              "red_colobus",
+              "cichlid",
+              "sheep",
+              "coati",
+              "sifaka_fossa",
+              "dolphin_human",
+              "social_foraging_bci",
+              "drone",
+              "tuanan_orangutan",
+              "wilddog"
+            ]
+          },
+          "server_address": {
+            "title": "Server Address",
+            "description": "location on server where data catalog entry is stored",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "people": {
+      "title": "People",
+      "description": "People involved in project. Make an an entry for each person.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "description": "researcher name",
+            "type": "string"
+          },
+          "institute": {
+            "title": "Institute",
+            "description": "institutional affiliation(s)",
+            "type": "string"
+          },
+          "email": {
+            "title": "Email",
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "email"
+              },
+              {
+                "type": "string",
+                "maxLength": 0
+              }
+            ]
+          },
+          "role": {
+            "title": "Role",
+            "description": "What is role in project (dropdown menu)",
+            "type": "string",
+            "enum": [
+              "PI",
+              "PhD Student",
+              "Masters Student",
+              "Collaborator",
+              "HIWI",
+              "Field Assistant",
+              "Lab Assistant",
+              "Analyst"
+            ]
+          },
+          "uploader": {
+            "title": "Uploader",
+            "description": "whether they are responsible for data catalog entry upload.",
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    },
+    "species": {
+      "title": "Species",
+      "description": "",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name_eng": {
+            "title": "Common Name (English)",
+            "description": "common name in english",
+            "type": "string"
+          },
+          "name_loc": {
+            "title": "Local Name",
+            "description": "local name at fieldsite (i.e. mono cariblanco)",
+            "type": "string"
+          },
+          "name_sci": {
+            "title": "Latin Name (Genus species)",
+            "description": "Linnean Genus species",
+            "type": "string"
+          }
+        }
+      }
+    },
+    "locations": {
+      "title": "Locations",
+      "description": "Info about location(s) of data collection.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "country": {
+            "title": "Country",
+            "description": "",
+            "type": "string",
+            "format": "country"
+          },
+          "region": {
+            "title": "State/Province/Region",
+            "description": "if applicable",
+            "type": "string"
+          },
+          "city": {
+            "title": "City or Town",
+            "description": "nearest city if applicable",
+            "type": "string"
+          },
+          "park": {
+            "title": "Park/Protected Area",
+            "description": "name of park or protected area if applicable",
+            "type": "string"
+          },
+          "field_station": {
+            "title": "Field Station",
+            "description": "name of field station i.e. BCI or Mpala or KOB if applicable",
+            "type": "string"
+          },
+          "lat_long": {
+            "title": "Lat Long",
+            "description": "Latitude (e.g. 9.167) and Longitude (e.g. 47.679) in Decimal Degrees",
+            "type": "string",
+            "format": "lat_long"
+          }
+        }
+      }
+    },
+    "dates": {
+      "title": "Dates",
+      "description": "Select a range of dates where data will be/was collected.",
+      "type": "object",
+      "properties": {
+        "start_date": {
+          "title": "Start Date",
+          "type": "string",
+          "format": "date"
+        },
+        "end_date": {
+          "title": "End Date",
+          "type": "string",
+          "format": "date"
+        }
+      }
+    },
+    "data_type_overview": {
+      "title": "Data Type Overview",
+      "description": "Type(s) of data that will be collected such as behavioral, movement, ecological, tissue samples. Select from a drop down menu, and let us know if you want to make another (or fork and modify changes and ask to merge)",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "examples": [
+          "behavioral",
+          "movement",
+          "vocalizations",
+          "ecological",
+          "climatic",
+          "camera trap",
+          "spatial",
+          "drone imagery",
+          "DNA samples",
+          "tissue samples"
+        ]
+      }
+    },
+    "data_file_type_overview": {
+      "title": "Data File Type Overview",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "examples": [
+          "tsv",
+          "txt",
+          "csv",
+          "mp3"
+        ]
+      }
+    },
+    "data_description": {
+      "title": "Data Description",
+      "description": "A brief free form text entry describing the data and general goals of project. Can be lifeted from your Data Management Plan.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "funding_sources": {
+      "title": "Funding Sources",
+      "description": "A list of all grants numbers, agencies, and istituons that funded this field work.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "keywords": {
+      "title": "Keywords",
+      "description": "Relevant Keywords that you think describe your project",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "modified_at": {
+      "title": "Modified At",
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/starwars.yml
+++ b/starwars.yml
@@ -1,35 +1,34 @@
 # Project Metadata: starwars
 project_name: starwars
-person_01:
-  name: Lea
-  institute: resistance
-  email: her_majesty@resistance.org
-  role: PI
-  date: 2021-05-21 - 2021-05-21
-person_02:
-  name: Luke
-  institute: jedi
-  email: luke@force.com
-  role: Collaborator
-  date: 2021-05-21 - 2021-05-21
-location_1:
-  country: death star
-  region: outer galaxy
-  park: park A
-  field_station: x475
-  lat_log: 54.43 N; 120.53 E
+people:
+  - name: Lea
+    institute: resistance
+    email: her_majesty@resistance.org
+    role: PI
+    date: 2021-05-21 - 2021-05-21
+  - name: Luke
+    institute: jedi
+    email: luke@force.com
+    role: Collaborator
+    date: 2021-05-21 - 2021-05-21
+locations:
+  - country: death star
+    region: outer galaxy
+    park: park A
+    field_station: x475
+    lat_log: 54.43 N; 120.53 E
 data_file_type_overview:
-  file_type_1: tsv
-  file_type_2: txt
-  file_type_3: csv
-  file_type_4: mp3
+  - tsv
+  - txt
+  - csv
+  - mp3
 data_description:
-  data_desc_1: x_file
-  data_desc_2: y_file
-  data_desc_3: z_file
+  - x_file
+  - y_file
+  - z_file
 dates:
   start_time: '2021-05-17'
   end_time: '2021-05-21'
 funding_sources:
-  fund_1: the free people
-  fund_2: everyone else
+  - the free people
+  - everyone else


### PR DESCRIPTION
There are a few minor discrepancies between the yamls that the the shiny app generates and the example. I'd like to codify the exact fields and what they mean before doing a round of encouraging people to document and archive their data. I've used [json schema](https://json-schema.org/) to note what the fields are. This version is my best representation of what is documented.

You can view a visual version of this by following these steps:

1) Got to this webpage: https://rjsf-team.github.io/react-jsonschema-form/
2) Click "Blank" in the top right (by default "Simple" is selected).
3) Paste our schema into the JSON Schema section. Easiest to copy from [here](https://raw.githubusercontent.com/livingingroups/data_catalog_entry_form_shiny_yml/add-schema/data-catalog-entry-schema.json).

You should see something like this:
<img width="760" alt="image" src="https://github.com/livingingroups/data_catalog_entry_form_shiny_yml/assets/16126168/46d40563-fa86-49ae-bdcd-de5a70169d26">
I am going to try to get a view like this to show up in the shiny app so people can enter their info and generate the yaml that way.

If you're using this method to review, make sure to click "+" for each field where it's an option in order to see the sub fields and how they display.

Note: one difference between this version, and the previous version is the previous version would have something like person_1, person_2 whereas this version has "people" as a key and the a list. (You can see this in the updated examples).

Areas were I would particularly like feedback:

- Which fields should be a single value or item vs a list of values or items?
- Which properties should be required? (Currently none are required so an empty file would be a valid entry.)
- In which areas or groups should we allow additional properties? (Currently they are allowed anywhere which kind of defeats the point of having a standardized schema.)
- Descriptions: I copied them from the README, but many seem like they could be improved.